### PR TITLE
Use local mutext

### DIFF
--- a/RepostConfirmationCanceler/Program.cs
+++ b/RepostConfirmationCanceler/Program.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 class Program
 {
-    private static Mutex MyMutex { get; } = new Mutex(false, @"Global\RepostConfirmationCancelerMutex");
+    private static Mutex MyMutex { get; } = new Mutex(false, @"RepostConfirmationCancelerMutex");
 
     [STAThread]
     static void Main()

--- a/RepostConfirmationCanceler/Properties/AssemblyInfo.cs
+++ b/RepostConfirmationCanceler/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      ビルド番号
 //      リビジョン
 //
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]

--- a/RepostConfirmationCancelerX64.iss
+++ b/RepostConfirmationCancelerX64.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=RepostConfirmationCanceler
 AppVerName=RepostConfirmationCanceler
-VersionInfoVersion=1.2.0.0
-AppVersion=1.2.0.0
+VersionInfoVersion=1.2.1.0
+AppVersion=1.2.1.0
 AppMutex=RepostConfirmationCancelerSetup
 ;DefaultDirName=C:\RepostConfirmationCanceler
 DefaultDirName={code:GetProgramFiles}\RepostConfirmationCanceler
@@ -24,7 +24,7 @@ UninstallDisplayIcon={app}\RepostConfirmationCanceler.exe
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.0.0"
+Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.1.0"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\RepostConfirmationCanceler.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\RepostConfirmationCanceler.exe"
@@ -32,7 +32,7 @@ Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; Va
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.0.0"
+Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.1.0"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\RepostConfirmationCanceler.ini"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\RepostConfirmationCanceler.exe"

--- a/RepostConfirmationCancelerX86.iss
+++ b/RepostConfirmationCancelerX86.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=RepostConfirmationCanceler
 AppVerName=RepostConfirmationCanceler
-VersionInfoVersion=1.2.0.0
-AppVersion=1.2.0.0
+VersionInfoVersion=1.2.1.0
+AppVersion=1.2.1.0
 AppMutex=RepostConfirmationCancelerSetup
 ;DefaultDirName=C:\RepostConfirmationCanceler
 DefaultDirName={code:GetProgramFiles}\RepostConfirmationCanceler
@@ -23,7 +23,7 @@ UninstallDisplayIcon={app}\RepostConfirmationCanceler.exe
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.0.0"
+Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.1.0"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\RepostConfirmationCanceler.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\RepostConfirmationCanceler.exe"


### PR DESCRIPTION
Some users fail to create a global mutex because they have no permission to create global object.
RepostConfirmationCanceler can work with a local mutex, so use it.
