### PR TITLE
Use per-user named pipe names

### DIFF
--- a/RepostConfirmationCancelerX64.iss
+++ b/RepostConfirmationCancelerX64.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=RepostConfirmationCanceler
 AppVerName=RepostConfirmationCanceler
-VersionInfoVersion=1.2.1.0
-AppVersion=1.2.1.0
+VersionInfoVersion=1.2.2.0
+AppVersion=1.2.2.0
 AppMutex=RepostConfirmationCancelerSetup
 ;DefaultDirName=C:\RepostConfirmationCanceler
 DefaultDirName={code:GetProgramFiles}\RepostConfirmationCanceler
@@ -24,7 +24,7 @@ UninstallDisplayIcon={app}\RepostConfirmationCanceler.exe
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.1.0"
+Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.2.0"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\RepostConfirmationCanceler.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\RepostConfirmationCanceler.exe"
@@ -32,7 +32,7 @@ Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; Va
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.1.0"
+Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.2.0"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\RepostConfirmationCanceler.ini"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\WOW6432Node\RepostConfirmationCanceler"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\RepostConfirmationCanceler.exe"

--- a/RepostConfirmationCancelerX86.iss
+++ b/RepostConfirmationCancelerX86.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=RepostConfirmationCanceler
 AppVerName=RepostConfirmationCanceler
-VersionInfoVersion=1.2.1.0
-AppVersion=1.2.1.0
+VersionInfoVersion=1.2.2.0
+AppVersion=1.2.2.0
 AppMutex=RepostConfirmationCancelerSetup
 ;DefaultDirName=C:\RepostConfirmationCanceler
 DefaultDirName={code:GetProgramFiles}\RepostConfirmationCanceler
@@ -23,7 +23,7 @@ UninstallDisplayIcon={app}\RepostConfirmationCanceler.exe
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.1.0"
+Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Version"; ValueData: "1.2.2.0"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\RepostConfirmationCanceler.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\RepostConfirmationCanceler"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\RepostConfirmationCanceler.exe"


### PR DESCRIPTION
When RepostConfirmationCanceler works in multi-session, named pipe names should be independent per user.
If we try to create a named pipe has a duplicated name to an already created named pipe, we can not create the named pipe with an `UnauthorizedAccessException` error.